### PR TITLE
feat: provide another type of lab header and add example of dip

### DIFF
--- a/examples/dip/report.typ
+++ b/examples/dip/report.typ
@@ -1,0 +1,66 @@
+#import "../../template.typ": *
+
+#show: project.with(
+  theme: "nocover",
+  author: "",
+  table_of_contents: false,
+)
+
+#lab_header_2(
+  major: "计算机科学与技术",
+  author: "xxx",
+  school_id: "xxxxxxxxxx",
+  date: "2025年1月32日", 
+  course: "图像信息处理",
+  teacher: "sml",
+  name: "xxxxxxx"
+)
+
+#v(1em)
+
+= 一、实验目的和要求
+
+#v(.5em)
+
+1. #lorem(10)
+2. #lorem(10)
+
+= 二、实验内容和原理
+
+#v(.5em)
+
+（简述实验有关的基本原理）
+
+#lorem(100)
+
+= 三、实验步骤与分析
+
+#v(.5em)
+
+（每个步骤结合对应部分的源代码分析）
+
+#lorem(100)
+
+= 四、实验环境及运行方法
+
+#v(.5em)
+
+（说明程序的编译环境和具体测试方法）
+
+#lorem(100)
+
+= 五、实验结果展示
+
+#v(.5em)
+
+（展示实验中的输入输出图像等）
+
+#lorem(100)
+
+= 六、心得体会
+
+#v(.5em)
+
+（个人收获与问题经验总结）
+
+#lorem(100)

--- a/template.typ
+++ b/template.typ
@@ -425,6 +425,63 @@
   )
 }
 
+#let lab_header_2(
+  major: none,
+  author: none,
+  school_id: none,
+  date: none,
+  course: none,
+  teacher: none,
+  grade: none,
+  name: none,
+) = {
+  
+    align(center)[
+      #grid(columns: 3, column-gutter: (-15pt, 20pt),[
+        #pad(y: -4pt)[]
+        #image("./images/ZJU-Banner.png", width: 75%)
+      ],[
+        #text(size: -10pt)[]  \ #text(size: 30pt, stroke: 1pt)[实验报告]
+      ], [
+        #align(left)[
+          #text(size: 1em)[
+            专业：#major\
+            姓名：#author \
+            学号：#school_id \
+            日期：#date\
+          ]
+        ]
+      ])
+    ]
+     
+  tablex(
+    columns: (1.3fr, 2fr, 1.3fr, 1fr, 1fr, 0.5fr),
+    align: left,
+    stroke: 0pt,
+    inset: 1pt,
+    _underlined_cell("课程名称：", color: white),
+    colspanx(1, _underlined_cell(
+      if course == none {
+        state_course.display()
+      } else {
+        course
+      }
+    )),
+    _underlined_cell("指导老师：", color: white),
+    colspanx(1, _underlined_cell(
+      teacher
+    )),
+    _underlined_cell("成绩：", color: white),
+    colspanx(1, _underlined_cell(
+      grade
+    )), 
+    _underlined_cell("实验名称：", color: white),
+    colspanx(4, _underlined_cell(
+      name
+    )), (), (), (),
+  )
+}
+
 #let table3( // 三线表
   ..args,
   inset: 0.5em,


### PR DESCRIPTION
新增了另一种风格的实验报告 header，《图像信息处理》等课程要求使用这类风格的报告。效果展示如下（该例子放在了 example 目录下的 dip 子目录）：

![report_页面_1](https://github.com/user-attachments/assets/c2d7165b-aa43-4d51-888d-b94f29d77f55)

